### PR TITLE
fix(loader): add preloader to remove unix bin path

### DIFF
--- a/__tests__/fixtures/request-cache/GET/localhost/.bin
+++ b/__tests__/fixtures/request-cache/GET/localhost/.bin
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-Date: Sat, 05 Nov 2016 05:55:07 GMT
+Date: Mon, 14 Nov 2016 20:39:16 GMT
 Connection: close
 Content-Length: 2
 

--- a/scripts/copy-dist-dependencies.js
+++ b/scripts/copy-dist-dependencies.js
@@ -8,19 +8,21 @@ const os = require('os');
 
 const basedir = path.join(__dirname, '../');
 const config = createWebpackConfig({
-  entry: [path.join(basedir, 'bin/test.js')],
+  entry: [path.join(basedir, 'bin/yarn.js')],
   output: {
     filename: `yarn-${Date.now()}.js`,
     path: os.tmpdir()
   }
 });
 config.bail = true;
-console.log(config);
+// console.log(config);
 const compiler = webpack(config);
 
 console.log(path.join(basedir, 'bin/yarn.js'));
 
 compiler.run((err, stats) => {
+  console.log(err, stats);
+
   const {fileDependencies} = stats.compilation;
 
   console.log(fileDependencies);

--- a/scripts/create-webpack-config.js
+++ b/scripts/create-webpack-config.js
@@ -7,15 +7,29 @@ module.exports = function createWebpackConfig(opts) {
     // devtool: 'inline-source-map',
     entry: opts.entry,
     module: {
-      loaders: [{
-        test: /\.js$/,
-        exclude: /node_modules/,
-        loader: 'babel',
-        query: opts.babelQuery || '',
-      }, {
+      loaders: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'strip-unix-bin-string-loader',
+          enforce: 'pre'
+        },
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'babel',
+          query: opts.babelQuery || '',
+        }, 
+        {
         test: /\.json$/,
         loader: 'json',
-      }],
+        }
+      ],
+    },
+    resolveLoader: {
+      alias: {
+        'strip-unix-bin-string-loader': require.resolve("./strip-unix-bin-string-loader")
+      }
     },
     plugins: [
       new webpack.BannerPlugin({

--- a/scripts/strip-unix-bin-string-loader.js
+++ b/scripts/strip-unix-bin-string-loader.js
@@ -1,0 +1,6 @@
+module.exports = function (source) {
+    let unixBinRegExp = /^\#\!.*$/gm
+    let newSource = source.replace(unixBinRegExp, "");
+
+    return newSource;
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Since unix bin paths are at the top of some of the yarn.js bin scripts, webpack's parser (acorn) chokes on the `#!` characters when parsing. This PR adds a loader which will string replace any js files before they are parsed with the following RegExp: 

`/^\#\!.*$/gm`

This is quick and dirty so if this needs to be iterated on, we can do so. 


**Test plan**
Not quite a test plan but you can see with the screen cap below that this works around acorn choking on the bin path. 

![screen shot 2016-11-14 at 2 55 03 pm](https://cloud.githubusercontent.com/assets/3408176/20315472/99c65872-ab23-11e6-87b5-1c967f41692c.png)

